### PR TITLE
feat: qol improvements

### DIFF
--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -33,9 +33,8 @@ jobs:
       - name: Prepare Theos
         uses: Randomblock1/theos-action@v1
 
-      - name: Prepare Azule
-        run : |
-          git clone https://github.com/Al4ise/Azule ${{ github.workspace }}/Azule
+      - name: Install cyan
+        run: pip install --force-reinstall https://github.com/asdfzxcvbn/pyzule-rw/archive/main.zip Pillow
 
       - name: Prepare Unbound Patcher
         run : |
@@ -53,10 +52,8 @@ jobs:
           gmake clean package
           mv $(find packages -name "*.deb" -print -quit) out/Unbound.deb
 
-      - name: Create Unbound.ipa
-        run : |
-          ${{ github.workspace }}/Azule/azule -i Unbound.ipa -o out -f out/unbound.deb
-          mv out/Unbound+unbound.deb.ipa out/Unbound.ipa
+      - name: Inject tweak
+        run: -duwsgq -i Unbound.ipa -o out/Unbound.ipa -f out/Unbound.deb
 
       - name: Build dev deb
         run: |
@@ -66,10 +63,8 @@ jobs:
           gmake clean package FINALPACKAGE=1 DEVTOOLS=1
           mv $(find packages -name "*.deb" -print -quit) out/Unbound.Development.deb
 
-      - name: Create Unbound.Dev.ipa
-        run : |
-          ${{ github.workspace }}/Azule/azule -i Unbound.ipa -o out -f out/Unbound.Development.deb
-          mv out/Unbound+Unbound.Development.deb.ipa out/Unbound.Development.ipa
+      - name: Inject dev tweak
+        run: -duwsgq -i Unbound.ipa -o out/Unbound.ipa -f out/Unbound.Development.deb
 
       - id: latestRelease
         uses: pozetroninc/github-action-get-latest-release@master

--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -53,7 +53,7 @@ jobs:
           mv $(find packages -name "*.deb" -print -quit) out/Unbound.deb
 
       - name: Inject tweak
-        run: -duwsgq -i Unbound.ipa -o out/Unbound.ipa -f out/Unbound.deb
+        run: cyan -duwsgq -i Unbound.ipa -o out/Unbound.ipa -f out/Unbound.deb
 
       - name: Build dev deb
         run: |
@@ -64,7 +64,7 @@ jobs:
           mv $(find packages -name "*.deb" -print -quit) out/Unbound.Development.deb
 
       - name: Inject dev tweak
-        run: -duwsgq -i Unbound.ipa -o out/Unbound.ipa -f out/Unbound.Development.deb
+        run: cyan -duwsgq -i Unbound.ipa -o out/Unbound.ipa -f out/Unbound.Development.deb
 
       - id: latestRelease
         uses: pozetroninc/github-action-get-latest-release@master

--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Build package
         run: |
           rm -f packages/*
-          gmake clean package FINALPACKAGE=1
+          gmake clean package
           mv $(find packages -name "*.deb" -print -quit) out/Unbound.deb
 
       - name: Create Unbound.ipa

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,6 @@ include $(THEOS_MAKE_PATH)/tweak.mk
 include $(THEOS_MAKE_PATH)/bundle.mk
 
 before-all::
-	$(ECHO_NOTHING)mkdir -p Resources$(ECHO_END)
 	$(ECHO_NOTHING)VERSION_NUM=$$(echo "$(THEOS_PACKAGE_BASE_VERSION)" | cut -d'.' -f1,2) && \
 		sed "s/VERSION_PLACEHOLDER/$$VERSION_NUM/" sources/preload.template.js > resources/preload.js$(ECHO_END)
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 THEOS_PACKAGE_SCHEME=rootless
+FINALPACKAGE=1
 INSTALL_TARGET_PROCESSES = Discord
 
 ARCHS := arm64 arm64e
@@ -7,15 +8,25 @@ TARGET := iphone:clang:latest:14.0
 include $(THEOS)/makefiles/common.mk
 
 LOGS = 0
-SIDELOAD = 1
 
 TWEAK_NAME = Unbound
 $(TWEAK_NAME)_FILES = $(shell find Sources -name "*.x*")
-$(TWEAK_NAME)_CFLAGS = -DLOGS=$(LOGS) -DSIDELOAD=$(SIDELOAD) -fobjc-arc
-$(TWEAK_NAME)_FRAMEWORKS = UIKit Foundation
+$(TWEAK_NAME)_CFLAGS =  -fobjc-arc -DPACKAGE_VERSION='@"$(THEOS_PACKAGE_BASE_VERSION)"' -DLOGS=$(LOGS) -I$(THEOS_PROJECT_DIR)/headers
+$(TWEAK_NAME)_FRAMEWORKS = UIKit Foundation UniformTypeIdentifiers
 
 BUNDLE_NAME = UnboundResources
 $(BUNDLE_NAME)_INSTALL_PATH = "/Library/Application\ Support/"
 
 include $(THEOS_MAKE_PATH)/tweak.mk
 include $(THEOS_MAKE_PATH)/bundle.mk
+
+before-all::
+	$(ECHO_NOTHING)mkdir -p Resources$(ECHO_END)
+	$(ECHO_NOTHING)VERSION_NUM=$$(echo "$(THEOS_PACKAGE_BASE_VERSION)" | cut -d'.' -f1,2) && \
+		sed "s/VERSION_PLACEHOLDER/$$VERSION_NUM/" sources/preload.template.js > resources/preload.js$(ECHO_END)
+
+after-stage::
+	$(ECHO_NOTHING)find $(THEOS_STAGING_DIR) -name ".DS_Store" -delete$(ECHO_END)
+
+after-package::
+	$(ECHO_NOTHING)rm resources/preload.js$(ECHO_END)

--- a/patch.sh
+++ b/patch.sh
@@ -2,7 +2,7 @@
 rm -rf packages
 
 # Compile into .deb
-gmake clean package LOGS=1 SIDELOAD=1
+gmake clean package LOGS=1
 
 # Rename newly created .deb
 find packages/*.deb -exec sh -c 'mv "$0" packages/Unbound.deb' {} \;

--- a/sources/FileSystem.x
+++ b/sources/FileSystem.x
@@ -1,4 +1,4 @@
-#import "../headers/FileSystem.h"
+#import "FileSystem.h"
 
 @implementation FileSystem
 	static NSMutableDictionary<NSString*, NSMutableDictionary*> *monitors = nil;

--- a/sources/Fonts.xm
+++ b/sources/Fonts.xm
@@ -1,4 +1,4 @@
-#import "../headers/Fonts.h"
+#import "Fonts.h"
 
 @implementation Fonts
 	static NSMutableDictionary<NSString*, NSString*> *overrides = nil;

--- a/sources/Misc.x
+++ b/sources/Misc.x
@@ -1,4 +1,5 @@
-#import "../headers/Misc.h"
+#import "Misc.h"
+#import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
 
 %hook SentrySDK
 	+ (void) startWithOptions:(id)options {
@@ -24,7 +25,7 @@
 %end
 
 // Fix issues with sideloading
-%group Sideload
+%group Sideloading
 	%hook NSFileManager
 		- (NSURL*)containerURLForSecurityApplicationGroupIdentifier:(NSString*)identifier {
 			if (identifier != nil) {
@@ -43,6 +44,82 @@
 
 			return %orig(identifier);
 		}
+	%end
+
+	// fix file access by using asCopy, adapted from https://github.com/khanhduytran0/LiveContainer/blob/main/TweakLoader/DocumentPicker.m
+	%hook UIDocumentPickerViewController
+
+	- (instancetype)initForOpeningContentTypes:(NSArray<UTType *> *)contentTypes asCopy:(BOOL)asCopy {
+		BOOL shouldMultiselect = NO;
+		if ([contentTypes count] == 1 && contentTypes[0] == UTTypeFolder) {
+			shouldMultiselect = YES;
+		}
+
+		NSArray<UTType *> *contentTypesNew = @[ UTTypeItem, UTTypeFolder ];
+
+		UIDocumentPickerViewController *ans = %orig(contentTypesNew, YES);
+		if (shouldMultiselect) {
+			[ans setAllowsMultipleSelection:YES];
+		}
+		return ans;
+	}
+
+	- (instancetype)initWithDocumentTypes:(NSArray<UTType *> *)contentTypes inMode:(NSUInteger)mode {
+		return [self initForOpeningContentTypes:contentTypes asCopy:(mode == 1 ? NO : YES)];
+	}
+
+	- (void)setAllowsMultipleSelection:(BOOL)allowsMultipleSelection {
+		if ([self allowsMultipleSelection]) {
+			return;
+		}
+		%orig(YES);
+	}
+
+	%end
+
+	%hook UIDocumentBrowserViewController
+
+	- (instancetype)initForOpeningContentTypes:(NSArray<UTType *> *)contentTypes {
+		NSArray<UTType *> *contentTypesNew = @[ UTTypeItem, UTTypeFolder ];
+		return %orig(contentTypesNew);
+	}
+
+	%end
+
+	%hook NSURL
+
+	- (BOOL)startAccessingSecurityScopedResource {
+		%orig;
+		return YES;
+	}
+
+	%end
+
+	// show icon change error alert
+	%hook UIApplication
+	- (void)setAlternateIconName:(NSString *)iconName
+			completionHandler:(void (^)(NSError *))completion {
+		void (^wrappedCompletion)(NSError *) = ^(NSError *error) {
+			if (error) {
+				[Utilities alert:@"For this to work change the Bundle ID so that it matches your provisioning profile's App ID (excluding the Team ID prefix)." title:@"Cannot Change Icon"];
+			}
+
+			if (completion) {
+				completion(error);
+			}
+		};
+
+		%orig(iconName, wrappedCompletion);
+	}
+	%end
+
+	// show passkey error alert
+	%hook ASAuthorizationController
+
+	- (void)performRequests {
+		[Utilities alert:@"Passkeys are not supported when sideloading Discord. Please use a different login method." title:@"Cannot Use Passkey"];
+	}
+
 	%end
 %end
 
@@ -79,7 +156,9 @@
 		%init(Debug)
 	}
 
-	if (SIDELOAD) {
-		%init(Sideload)
-	}
+	BOOL isAppStoreApp = [[NSFileManager defaultManager]
+        fileExistsAtPath:[[NSBundle mainBundle] appStoreReceiptURL].path];
+    if (!isAppStoreApp) {
+        %init(Sideloading);
+    }
 }

--- a/sources/Plugins.x
+++ b/sources/Plugins.x
@@ -1,4 +1,4 @@
-#import "../headers/Plugins.h"
+#import "Plugins.h"
 
 @implementation Plugins
 	static NSMutableArray *plugins = nil;

--- a/sources/Settings.x
+++ b/sources/Settings.x
@@ -1,4 +1,4 @@
-#import "../headers/Settings.h"
+#import "Settings.h"
 
 @implementation Settings
 	static NSMutableDictionary *data = nil;

--- a/sources/Themes.xm
+++ b/sources/Themes.xm
@@ -1,4 +1,4 @@
-#import "../headers/Themes.h"
+#import "Themes.h"
 #import <objc/runtime.h>
 #import <substrate.h>
 

--- a/sources/Unbound.x
+++ b/sources/Unbound.x
@@ -1,4 +1,4 @@
-#import "../headers/Unbound.h"
+#import "Unbound.h"
 
 %hook RCTCxxBridge
 	- (void) executeApplicationScript:(NSData *)script url:(NSURL *)url async:(BOOL)async {

--- a/sources/Updater.x
+++ b/sources/Updater.x
@@ -1,4 +1,4 @@
-#import "../headers/Updater.h"
+#import "Updater.h"
 
 @implementation Updater
 	static NSString *etag = nil;

--- a/sources/Utilities.x
+++ b/sources/Utilities.x
@@ -1,7 +1,7 @@
 #import <CommonCrypto/CommonCrypto.h>
 
-#import "../headers/FileSystem.h"
-#import "../headers/Utilities.h"
+#import "FileSystem.h"
+#import "Utilities.h"
 #import <rootless.h>
 
 @implementation Utilities

--- a/sources/preload.template.js
+++ b/sources/preload.template.js
@@ -5,7 +5,7 @@ this.UNBOUND_FONTS = %@;
 this.UNBOUND_AVAILABLE_FONTS = %@;
 
 this.UNBOUND_LOADER = {
-	platform: 'iOS',
-	origin: 'Substrate',
-	version: 1.0
+    platform: 'iOS',
+    origin: 'Substrate',
+    version: VERSION_PLACEHOLDER
 };

--- a/sources/preload.template.js
+++ b/sources/preload.template.js
@@ -5,7 +5,7 @@ this.UNBOUND_FONTS = %@;
 this.UNBOUND_AVAILABLE_FONTS = %@;
 
 this.UNBOUND_LOADER = {
-    platform: 'iOS',
-    origin: 'Substrate',
-    version: VERSION_PLACEHOLDER
+        platform: 'iOS',
+        origin: 'Substrate',
+        version: VERSION_PLACEHOLDER
 };


### PR DESCRIPTION
this pr ports a few of the qol changes I've implemented in recent versions of [bunny-mod/BunnyTweak](https://github.com/bunny-mod/BunnyTweak):
- cleaned up relative import paths
- dynamically insert version into `preload.js`
- assert sideloading status at runtime
- fix file access if the application is signed with an ADP cert
- show alerts when users try to use a passkey or change an app icon whilst the application is signed with an ADP cert
- replace azule with cyan as azule is deprecated

additional qol improvements I would suggest for the future are:
- extended info in the bundle fetch failure alert (such as suggesting to change the network/dns server)
- a bit more of a dynamic deploy workflow as seen in [workflows/deploy.yml](https://github.com/bunny-mod/BunnyTweak/blob/main/.github/workflows/deploy.yml)
- automated ipa releases akin to [workflows/remote-deploy.yml](https://github.com/bunny-mod/BunnyTweak/blob/main/.github/workflows/remote-deploy.yml) & [castdrian/dipa-auto
](https://github.com/castdrian/dipa-auto)
- automated altsource repo for on-device signing applications such as feather or altstore
- native troubleshooting menu akin to [Sources/Settings.m](https://github.com/bunny-mod/BunnyTweak/blob/main/Sources/Settings.m)
- for vsc users reccomended extensions & tasks can be added that act as build shortcuts, see [main/.vscode](https://github.com/bunny-mod/BunnyTweak/tree/main/.vscode)
- formatting with clangformat & logos-format

furthermore you are free to bundle the [castdrian/OpenInDiscord ](https://github.com/castdrian/OpenInDiscord) extension if so desired